### PR TITLE
Implement basic A2A router

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ secrets.env
 
 # 설치 상태 파일
 installation_state.json
+.venv/

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ for event in stream:
 - 🚄 **High Performance** Automatic parallelism and prefix caching
 - 📡 **Streaming** Stream browser-augmented LLM output to users
 - 📊 **Concurrency** Out-of-the-box support many users with efficient resource management
+- 🔌 **A2A Router** Built-in message router and context manager for agent-to-agent communication
 
 ## 📄 MIT License
 

--- a/blastai/__init__.py
+++ b/blastai/__init__.py
@@ -14,6 +14,7 @@ setup_logging()
 from .engine import Engine
 from .server import app, init_app_state
 from .config import Settings, Constraints
+from .a2a_router import AgentRouter, ContextManager
 
 __all__ = [
     'Engine',
@@ -21,4 +22,6 @@ __all__ = [
     'init_app_state',
     'Settings',
     'Constraints',
+    'AgentRouter',
+    'ContextManager',
 ]

--- a/blastai/a2a_router.py
+++ b/blastai/a2a_router.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+"""Simple A2A router and MCP context manager."""
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+
+@dataclass
+class AgentMessage:
+    """Standardized message between agents."""
+
+    sender: str
+    receiver: str
+    type: str
+    payload: Dict[str, Any]
+
+
+AgentHandler = Callable[[AgentMessage], Awaitable[Optional[AgentMessage]]]
+
+
+class AgentRouter:
+    """Central router for A2A communication."""
+
+    def __init__(self) -> None:
+        self._agents: Dict[str, AgentHandler] = {}
+        self._queue: asyncio.Queue[AgentMessage] = asyncio.Queue()
+        self._running = False
+        self._task: Optional[asyncio.Task] = None
+
+    def register_agent(self, name: str, handler: AgentHandler) -> None:
+        """Register an agent with its message handler."""
+        self._agents[name] = handler
+
+    async def start(self) -> None:
+        """Start the routing loop."""
+        if not self._running:
+            self._running = True
+            self._task = asyncio.create_task(self._route_loop())
+
+    async def stop(self) -> None:
+        """Stop the routing loop."""
+        if self._running:
+            self._running = False
+            if self._task:
+                self._task.cancel()
+                try:
+                    await self._task
+                except asyncio.CancelledError:
+                    pass
+
+    async def send(self, message: AgentMessage) -> None:
+        """Queue a message for delivery."""
+        await self._queue.put(message)
+
+    async def _route_loop(self) -> None:
+        while self._running:
+            try:
+                message = await self._queue.get()
+            except asyncio.CancelledError:
+                break
+            handler = self._agents.get(message.receiver)
+            if handler:
+                try:
+                    response = await handler(message)
+                    if response:
+                        await self._queue.put(response)
+                except Exception:
+                    # Ignore handler errors to keep router alive
+                    pass
+
+
+class ContextManager:
+    """Minimal MCP context storage."""
+
+    def __init__(self) -> None:
+        self._contexts: Dict[str, Dict[str, Any]] = {}
+
+    def get(self, user_id: str) -> Dict[str, Any]:
+        """Get context for a user."""
+        return self._contexts.setdefault(user_id, {})
+
+    def update(self, user_id: str, data: Dict[str, Any]) -> None:
+        """Update context for a user."""
+        ctx = self._contexts.setdefault(user_id, {})
+        ctx.update(data)


### PR DESCRIPTION
## Summary
- add `a2a_router` providing an Agent-to-Agent message router and simple MCP context manager
- expose `AgentRouter` and `ContextManager` from package init
- document the A2A router in README

## Testing
- `pytest -q` *(fails: command not found)*